### PR TITLE
docs: remove "npm install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ A decentralized virtual pet game built on the Nostr protocol. Each Nostr account
 
 ### Development
 ```bash
-npm install
 npm run dev
 ```
 


### PR DESCRIPTION
The `npm run dev` already contains `npm i`