### PR TITLE
enforce only one relay connection at the time

### DIFF
--- a/src/components/NostrProvider.tsx
+++ b/src/components/NostrProvider.tsx
@@ -12,10 +12,12 @@ const NostrProvider: React.FC<NostrProviderProps> = (props) => {
 
   // Create NPool instance and update it when relays change
   const pool = useRef<NPool | undefined>(undefined);
-  
+  const cleanupInProgress = useRef(false);
+
   // Memoize the pool configuration to prevent unnecessary recreations
   const poolConfig = useMemo(() => ({
     open(url: string) {
+      console.log('🔗 Opening connection to relay:', url);
       return new NRelay1(url);
     },
     reqRouter(filters: NostrFilter[]) {
@@ -28,17 +30,46 @@ const NostrProvider: React.FC<NostrProviderProps> = (props) => {
 
   // Create or recreate pool when configuration changes
   useEffect(() => {
+    // Prevent multiple simultaneous cleanup operations
+    if (cleanupInProgress.current) {
+      return;
+    }
+
+    // Cleanup old pool if it exists
+    const oldPool = pool.current;
+    if (oldPool) {
+      cleanupInProgress.current = true;
+      console.log('🧹 Cleaning up old Nostr pool...');
+      oldPool.close().then(() => {
+        console.log('✅ Old pool cleanup completed');
+        cleanupInProgress.current = false;
+      }).catch((error) => {
+        console.warn('⚠️ Error during pool cleanup:', error);
+        cleanupInProgress.current = false;
+      });
+    }
+
     if (relays.length > 0) {
       pool.current = new NPool(poolConfig);
       console.log('🔗 Nostr pool updated with relays:', relays);
+    } else {
+      pool.current = undefined;
     }
-  }, [poolConfig, relays]);
 
-  // Initialize pool if not created yet
-  if (!pool.current && relays.length > 0) {
-    pool.current = new NPool(poolConfig);
-    console.log('🔗 Nostr pool initialized with relays:', relays);
-  }
+    // Cleanup function for when component unmounts or relays change
+    return () => {
+      if (pool.current && !cleanupInProgress.current) {
+        cleanupInProgress.current = true;
+        console.log('🔄 Effect cleanup: closing pool...');
+        pool.current.close().then(() => {
+          cleanupInProgress.current = false;
+        }).catch((error) => {
+          console.warn('⚠️ Error during effect cleanup:', error);
+          cleanupInProgress.current = false;
+        });
+      }
+    };
+  }, [poolConfig, relays]);
 
   return (
     <NostrContext.Provider value={{ nostr: pool.current! }}>

--- a/src/hooks/useRelayManager.ts
+++ b/src/hooks/useRelayManager.ts
@@ -54,19 +54,19 @@ export function useRelayManager() {
   // Connect to a specific relay
   const connectToRelay = useCallback(async (url: string): Promise<boolean> => {
     try {
-      setRelays(prev => prev.map(relay => 
-        relay.url === url 
+      setRelays(prev => prev.map(relay =>
+        relay.url === url
           ? { ...relay, status: 'connecting' as const }
           : relay
       ));
 
       // Test the relay connection by creating a WebSocket
       const success = await testRelayConnection(url);
-      
-      setRelays(prev => prev.map(relay => 
-        relay.url === url 
-          ? { 
-              ...relay, 
+
+      setRelays(prev => prev.map(relay =>
+        relay.url === url
+          ? {
+              ...relay,
               connected: success,
               status: success ? 'connected' as const : 'error' as const,
               lastConnected: success ? Date.now() : relay.lastConnected
@@ -77,8 +77,8 @@ export function useRelayManager() {
       return success;
     } catch (error) {
       console.error(`Failed to connect to relay ${url}:`, error);
-      setRelays(prev => prev.map(relay => 
-        relay.url === url 
+      setRelays(prev => prev.map(relay =>
+        relay.url === url
           ? { ...relay, connected: false, status: 'error' as const }
           : relay
       ));
@@ -127,7 +127,7 @@ export function useRelayManager() {
 
   // Auto-connect to enabled relays on initial load
   const [hasInitialized, setHasInitialized] = useState(false);
-  
+
   useEffect(() => {
     if (relays.length > 0 && !hasInitialized) {
       setHasInitialized(true);
@@ -156,12 +156,12 @@ export function useRelayManager() {
   const disconnectFromRelay = useCallback(async (url: string): Promise<void> => {
     try {
       // In a real implementation, you would disconnect from the relay here
-      setRelays(prev => prev.map(relay => 
-        relay.url === url 
-          ? { 
-              ...relay, 
-              connected: false, 
-              status: 'disconnected' as const 
+      setRelays(prev => prev.map(relay =>
+        relay.url === url
+          ? {
+              ...relay,
+              connected: false,
+              status: 'disconnected' as const
             }
           : relay
       ));
@@ -172,8 +172,8 @@ export function useRelayManager() {
 
   // Toggle relay enabled/disabled state
   const toggleRelay = useCallback(async (url: string, enabled: boolean) => {
-    setRelays(prev => prev.map(relay => 
-      relay.url === url 
+    setRelays(prev => prev.map(relay =>
+      relay.url === url
         ? { ...relay, enabled }
         : relay
     ));
@@ -212,7 +212,7 @@ export function useRelayManager() {
     };
 
     setRelays(prev => [...prev, newRelay]);
-    
+
     // Attempt to connect to the new relay
     return await connectToRelay(url);
   }, [relays, connectToRelay]);
@@ -221,7 +221,7 @@ export function useRelayManager() {
   const removeRelay = useCallback(async (url: string) => {
     // Disconnect first if connected
     await disconnectFromRelay(url);
-    
+
     // Remove from list
     setRelays(prev => prev.filter(relay => relay.url !== url));
   }, [disconnectFromRelay]);
@@ -241,7 +241,7 @@ export function useRelayManager() {
   const addDefaultRelays = useCallback(async () => {
     const existingUrls = relays.map(r => r.url);
     const newRelays = DEFAULT_RELAYS.filter(url => !existingUrls.includes(url));
-    
+
     if (newRelays.length === 0) {
       throw new Error('All default relays are already added');
     }


### PR DESCRIPTION
This fixes: https://github.com/Danidfra/nostr-pet/issues/10

Before this, the client connected to the same relay multiple times, this time, it only creates a new relay connection if the previous one was closed.